### PR TITLE
handles zip files related to a work

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ PATH
       haml
       rails (~> 5.1.6)
       rdf
+      rubyzip
       sidekiq
 
 GEM
@@ -159,7 +160,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     rake (12.3.2)
-    rdf (3.0.9)
+    rdf (3.0.10)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
     redis (4.1.0)
@@ -193,6 +194,7 @@ GEM
     rubocop-rspec (1.30.1)
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
+    rubyzip (1.2.2)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
     sidekiq (5.2.5)

--- a/app/models/concerns/hyrax/migrator/has_working_directory.rb
+++ b/app/models/concerns/hyrax/migrator/has_working_directory.rb
@@ -1,4 +1,9 @@
+# frozen_string_literal: true
+
 module Hyrax::Migrator
+  # Gives the ability to dynamically create a working directory when the
+  # file_path is pointing at a zip file or an S3 url, otherwise returns
+  # the original directory set in file_path.
   module HasWorkingDirectory
     extend ActiveSupport::Concern
 

--- a/app/models/concerns/hyrax/migrator/has_working_directory.rb
+++ b/app/models/concerns/hyrax/migrator/has_working_directory.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'zip'
+require 'tmpdir'
+require 'fileutils'
+
 module Hyrax::Migrator
   # Gives the ability to dynamically create a working directory when the
   # file_path is pointing at a zip file or an S3 url, otherwise returns

--- a/app/models/concerns/hyrax/migrator/has_working_directory.rb
+++ b/app/models/concerns/hyrax/migrator/has_working_directory.rb
@@ -1,0 +1,42 @@
+module Hyrax::Migrator
+  module HasWorkingDirectory
+    extend ActiveSupport::Concern
+
+    def working_directory
+      @working_directory ||= build_working_directory
+    end
+
+    def remove_temp_directory
+      return true if self[:file_path] == working_directory
+
+      # The working directory is not the original file_path, it is expected to
+      # be a temporary directory that should be removed.
+      FileUtils.rm_rf(working_directory)
+      !Dir.exist?(working_directory)
+    end
+
+    private
+
+    def build_working_directory
+      # TODO: Consider if file_path could be an S3 url, fetch url before handling it?
+      return extract_zip(self[:file_path], self[:pid]) if %w[zip gz].include?(self[:file_path].split('.').last)
+
+      self[:file_path]
+    end
+
+    ##
+    # Extract the zip file at source_path to a tmpdir for processing. NOTE: The temp directory
+    # is created but never removed, this is intented so that any actor can get access to the files
+    # during processing. Because these processes are running on emphemeral containers, the temp
+    # directory cannot be expected to exist between multiple runs (restarting the process).
+    def extract_zip(source_path, pid)
+      destination_path = Dir.mktmpdir([pid, Time.now.to_i.to_s])
+      Zip::File.open(source_path) do |zipfile|
+        zipfile.each do |entry|
+          entry.extract(File.join(destination_path, entry.to_s))
+        end
+      end
+      destination_path
+    end
+  end
+end

--- a/app/models/hyrax/migrator/work.rb
+++ b/app/models/hyrax/migrator/work.rb
@@ -7,46 +7,11 @@ require 'fileutils'
 module Hyrax::Migrator
   # A work represents the bag
   class Work < ApplicationRecord
+    include Hyrax::Migrator::HasWorkingDirectory
+
     SUCCESS = 'success'
     FAIL = 'fail'
 
     serialize :env, Hash
-
-    def working_directory
-      @working_directory ||= build_working_directory
-    end
-
-    def remove_temp_directory
-      return true if self[:file_path] == working_directory
-
-      # The working directory is not the original file_path, it is expected to
-      # be a temporary directory that should be removed.
-      FileUtils.rm_rf(working_directory)
-      !Dir.exist?(working_directory)
-    end
-
-    private
-
-    def build_working_directory
-      # TODO: Consider if file_path could be an S3 url, fetch url before handling it?
-      return extract_zip(self[:file_path], self[:pid]) if %w[zip gz].include?(self[:file_path].split('.').last)
-
-      self[:file_path]
-    end
-
-    ##
-    # Extract the zip file at source_path to a tmpdir for processing. NOTE: The temp directory
-    # is created but never removed, this is intented so that any actor can get access to the files
-    # during processing. Because these processes are running on emphemeral containers, the temp
-    # directory cannot be expected to exist between multiple runs (restarting the process).
-    def extract_zip(source_path, pid)
-      destination_path = Dir.mktmpdir([pid, Time.now.to_i.to_s])
-      Zip::File.open(source_path) do |zipfile|
-        zipfile.each do |entry|
-          entry.extract(File.join(destination_path, entry.to_s))
-        end
-      end
-      destination_path
-    end
   end
 end

--- a/app/models/hyrax/migrator/work.rb
+++ b/app/models/hyrax/migrator/work.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'zip'
+require 'tmpdir'
+require 'fileutils'
+
 module Hyrax::Migrator
   # A work represents the bag
   class Work < ApplicationRecord
@@ -7,5 +11,42 @@ module Hyrax::Migrator
     FAIL = 'fail'
 
     serialize :env, Hash
+
+    def working_directory
+      @working_directory ||= build_working_directory
+    end
+
+    def remove_temp_directory
+      return true if self[:file_path] == working_directory
+
+      # The working directory is not the original file_path, it is expected to
+      # be a temporary directory that should be removed.
+      FileUtils.rm_rf(working_directory)
+      !Dir.exist?(working_directory)
+    end
+
+    private
+
+    def build_working_directory
+      # TODO: Consider if file_path could be an S3 url, fetch url before handling it?
+      return extract_zip(self[:file_path], self[:pid]) if %w[zip gz].include?(self[:file_path].split('.').last)
+
+      self[:file_path]
+    end
+
+    ##
+    # Extract the zip file at source_path to a tmpdir for processing. NOTE: The temp directory
+    # is created but never removed, this is intented so that any actor can get access to the files
+    # during processing. Because these processes are running on emphemeral containers, the temp
+    # directory cannot be expected to exist between multiple runs (restarting the process).
+    def extract_zip(source_path, pid)
+      destination_path = Dir.mktmpdir([pid, Time.now.to_i.to_s])
+      Zip::File.open(source_path) do |zipfile|
+        zipfile.each do |entry|
+          entry.extract(File.join(destination_path, entry.to_s))
+        end
+      end
+      destination_path
+    end
   end
 end

--- a/app/models/hyrax/migrator/work.rb
+++ b/app/models/hyrax/migrator/work.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'zip'
-require 'tmpdir'
-require 'fileutils'
-
 module Hyrax::Migrator
   # A work represents the bag
   class Work < ApplicationRecord

--- a/hyrax-migrator.gemspec
+++ b/hyrax-migrator.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'bagit'
   s.add_dependency 'haml'
   s.add_dependency 'rails', '~> 5.1.6'
-  s.add_dependency 'rubyzip'
   s.add_dependency 'rdf'
+  s.add_dependency 'rubyzip'
   s.add_dependency 'sidekiq'
 
   s.add_development_dependency 'byebug'

--- a/hyrax-migrator.gemspec
+++ b/hyrax-migrator.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'bagit'
   s.add_dependency 'haml'
   s.add_dependency 'rails', '~> 5.1.6'
+  s.add_dependency 'rubyzip'
   s.add_dependency 'rdf'
   s.add_dependency 'sidekiq'
 

--- a/spec/hyrax/migrator/work_spec.rb
+++ b/spec/hyrax/migrator/work_spec.rb
@@ -1,9 +1,30 @@
 # frozen_string_literal:true
 
+require 'zip'
+
 RSpec.describe Hyrax::Migrator::Work do
   let(:model) { create(:work) }
+  let(:zip_file) { File.join(Rails.root, 'tmp', "test-#{Time.now.to_i}.zip") }
 
   it { expect(model.env).to be_a Hash }
   it { expect(described_class::SUCCESS).to eq('success') }
   it { expect(described_class::FAIL).to eq('fail') }
+  it { expect(model.working_directory).to eq model[:file_path] }
+  it { expect(model.remove_temp_directory).to be_truthy }
+
+  context 'with a temporary directory containing the unzipped file' do
+    before do
+      Zip::File.open(zip_file, Zip::File::CREATE) do |zipfile|
+        zipfile.add('Gemfile', File.join(Rails.root, '../../Gemfile'))
+      end
+      model[:file_path] = zip_file
+    end
+
+    after do
+      File.unlink(zip_file)
+    end
+
+    it { expect(model.working_directory).not_to eq(zip_file) }
+    it { expect(model.remove_temp_directory).to be_truthy }
+  end
 end


### PR DESCRIPTION
When the Work.file_path is at `.gz` or `.zip` file, then this PR extracts the zip file into a temporary location, or just points at the original `file_path` if it is not a zip file.

The follow-on to this work is to make services use `work.working_directory` instead of `work[:file_path]` when working with files in the bag.

fixes #35