### PR TITLE
check if admin set already exists

### DIFF
--- a/lib/hyrax/migrator/hyrax_core/admin_set.rb
+++ b/lib/hyrax/migrator/hyrax_core/admin_set.rb
@@ -15,7 +15,7 @@ module Hyrax::Migrator
       # @input [String] - Title
       # :nocov:
       def self.find(id)
-        ::AdminSet.find(id)
+        ::AdminSet.find(id) if ::AdminSet.exists?(id)
       end
       # :nocov:
     end


### PR DESCRIPTION
ActiveFedora raises an exception when an admin set is not found:
```
ActiveFedora::ObjectNotFoundError: Couldn't find AdminSet with 'id'=admin_set/defaulte
from /usr/local/bundle/gems/active-fedora-11.5.4/lib/active_fedora/relation/finder_methods.rb:201:in `raise_record_not_found_exception!'
```
