### PR TITLE
Load file identity service

### DIFF
--- a/app/actors/hyrax/migrator/actors/file_identity_actor.rb
+++ b/app/actors/hyrax/migrator/actors/file_identity_actor.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Hyrax::Migrator::Actors
+  # Retrieves content file checksums from manifest files in the bag
+  class FileIdentityActor < Hyrax::Migrator::Actors::AbstractActor
+    aasm do
+      state :file_identity_initial, initial: true
+      state :file_identity_succeeded, :file_identity_failed
+
+      event :file_identity_initial do
+        transitions from: %i[file_identity_initial file_identity_failed],
+                    to: :file_identity_initial
+      end
+      event :file_identity_failed, after: :post_fail do
+        transitions from: :file_identity_initial,
+                    to: :file_identity_failed
+      end
+      event :file_identity_succeeded, after: :post_success do
+        transitions from: :file_identity_initial,
+                    to: :file_identity_succeeded
+      end
+    end
+
+    def create(work)
+      super
+      file_identity_initial
+      update_work(aasm.current_state)
+      @checksums = service.content_file_checksums
+      @checksums ? file_identity_succeeded : file_identity_failed
+    rescue StandardError => e
+      file_identity_failed
+      log("failed retrieving file checksums: #{e.message} : #{e.backtrace}")
+    end
+
+    private
+
+    #:nocov:
+    def service
+      @service ||= Hyrax::Migrator::Services::LoadFileIdentityService.new(@work.working_directory)
+    end
+    #:nocov:
+
+    def post_success
+      @work.env[:files] = @checksums
+      succeeded(aasm.current_state, "Work #{@work.pid} Successfully retrieved checksums data from bag manifest files.", Hyrax::Migrator::Work::SUCCESS)
+    end
+
+    def post_fail
+      failed(aasm.current_state, "Work #{@work.pid} Unable to retrieve checksums data from bag manifest files.", Hyrax::Migrator::Work::FAIL)
+    end
+  end
+end

--- a/app/services/hyrax/migrator/services/load_file_identity_service.rb
+++ b/app/services/hyrax/migrator/services/load_file_identity_service.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Hyrax::Migrator::Services
+  # Called by the FileUploadActor to store checksum values in the env hash
+  class LoadFileIdentityService
+    def initialize(work_file_path)
+      @work_file_path = work_file_path
+      @manifest_files = manifest_files
+    end
+
+    # Load the manifest files to get the identify hash array for an existing
+    # file content.
+    #
+    # @return an array of hashes containing checksum data, content file name, and
+    # checksum encoding
+    def content_file_checksums
+      @manifest_files.map { |f| identity_hash(f) }
+    end
+
+    private
+
+    def identity_hash(file)
+      encoding = checksum_algorithm(file)
+      data = get_checksum_data(encoding)
+      { file_name: File.basename(data[:relative_path]), checksum: data[:checksum], checksum_encoding: encoding } if data.present?
+    end
+
+    # Extract the checksum algorithm from a manifest file basename that should come in the form
+    # "manifest-{algorithm}.txt"
+    #
+    def checksum_algorithm(file)
+      items = File.basename(file, '.txt').split('-')
+      items.last
+    end
+
+    def get_checksum_data(encoding)
+      case encoding
+      when 'sha1'
+        read_checksum_data('sha1')
+      when 'md5'
+        read_checksum_data('md5')
+      end
+    end
+
+    def read_checksum_data(algo)
+      file_algo = @manifest_files.detect { |f| File.basename(f) == "manifest-#{algo}.txt" }
+      data = read_manifest(file_algo)
+      data.detect { |l| l[:relative_path].include? '_content' } if data.present?
+    end
+
+    def read_manifest(file)
+      File.open(file).readlines.map { |line| { checksum: line.split(/\s+/).first, relative_path: line.split(/\s+/).last } }
+    end
+
+    def manifest_files
+      files = Dir.entries(@work_file_path).select do |f|
+        file = File.join(@work_file_path, f)
+        File.file?(file) && File.basename(file) =~ /^manifest-.*.txt$/
+      end
+      log_and_raise("could not find the manifest files with pattern manifest-[algorithm].txt in #{@work_file_path}") unless files.present?
+
+      files.map { |f| File.join(@work_file_path, f) }
+    rescue Errno::ENOENT
+      log_and_raise("data directory #{@work_file_path} not found")
+    end
+
+    def log_and_raise(message)
+      Rails.logger.error(message)
+      raise StandardError, message
+    end
+  end
+end

--- a/spec/hyrax/migrator/actors/file_identity_actor_spec.rb
+++ b/spec/hyrax/migrator/actors/file_identity_actor_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Migrator::Actors::FileIdentityActor do
+  let(:actor) { described_class.new }
+  let(:terminal) { Hyrax::Migrator::Actors::TerminalActor.new }
+  let(:work_file_path) { File.join(Rails.root, '..', 'fixtures', pid) }
+  let(:work) { create(:work, pid: pid) }
+  let(:test_checksum) do
+    {
+      file_name: 'test',
+      checksum: 'test',
+      checksum_encoding: 'sha1'
+    }
+  end
+  let(:service) { instance_double('Hyrax::Migrator::Services::LoadFileIdentityService') }
+
+  let(:pid) { 'abcde1234' }
+
+  describe '#create' do
+    context 'when the validation succeeds' do
+      before do
+        allow(Hyrax::Migrator::Services::LoadFileIdentityService).to receive(:new).and_return(service)
+        allow(service).to receive(:content_file_checksums).and_return([test_checksum])
+        allow(work).to receive(:working_directory).and_return(work_file_path)
+        actor.next_actor = terminal
+      end
+
+      it 'updates the work' do
+        actor.create(work)
+        expect(work.aasm_state).to eq('file_identity_succeeded')
+      end
+      it 'calls the next actor' do
+        expect(terminal).to receive(:create)
+        actor.create(work)
+      end
+    end
+
+    context 'when the validation fails' do
+      let(:error) { StandardError }
+      let(:work_file_path) { 'unknown-path' }
+
+      before do
+        allow(service).to receive(:content_file_checksums).and_raise(error)
+        actor.next_actor = terminal
+      end
+
+      it 'updates the work' do
+        actor.create(work)
+        expect(work.aasm_state).to eq('file_identity_failed')
+      end
+      it 'does not call the next actor' do
+        expect(terminal).not_to receive(:create)
+        actor.create(work)
+      end
+    end
+
+    context 'when the process blows up' do
+      let(:error) { StandardError.new('my-error') }
+
+      before do
+        allow(service).to receive(:content_file_checksums).and_raise(error)
+        actor.next_actor = terminal
+      end
+
+      it 'logs the failure' do
+        expect(Rails.logger).to receive(:warn)
+        actor.create(work)
+      end
+    end
+  end
+end

--- a/spec/hyrax/migrator/services/load_file_identity_service_spec.rb
+++ b/spec/hyrax/migrator/services/load_file_identity_service_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Migrator::Services::LoadFileIdentityService do
+  let(:pid) { '3t945r08v' }
+  let(:work_file_path) { File.join(Rails.root, '..', 'fixtures', pid) }
+  let(:service) { described_class.new(work_file_path) }
+
+  describe '#content_file_checksums' do
+    context 'when there are default manifest files' do
+      let(:expected_md5_data) do
+        {
+          file_name: '3t945r08v_content.jpeg',
+          checksum: 'cd36b025f4393ace2caa47c6e65f25ed',
+          checksum_encoding: 'md5'
+        }
+      end
+      let(:expected_sha1_data) do
+        {
+          file_name: '3t945r08v_content.jpeg',
+          checksum: 'c1249a0e4d7c8cf64f5de6892681287e34a87b10',
+          checksum_encoding: 'sha1'
+        }
+      end
+
+      it 'returns the an array of two hashes for default encoding' do
+        expect(service.content_file_checksums).to include(expected_sha1_data, expected_md5_data)
+      end
+    end
+
+    context 'when work_file_path (bag directory) does not exist' do
+      let(:error) { StandardError }
+      let(:work_file_path) { 'unknown-path' }
+
+      it 'raises an error' do
+        expect { service.content_file_checksums }.to raise_error(error)
+      end
+    end
+
+    context 'when it cant find manifest files for given bag' do
+      let(:error) { StandardError }
+
+      before do
+        allow(File).to receive(:basename).with(anything).and_return('invalid-format-manifest-file.txt')
+      end
+
+      it 'raises an error' do
+        expect { service.content_file_checksums }.to raise_error(error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
fixes https://github.com/OregonDigital/hyrax-migrator/issues/112

Adds `LoadFileIdentityService` and `FileIdentityActor`. `LoadFileIdentityService` retrieves content file checksums and available encodings. `FileIdentityActor` set the service results in work.env[:files].

`LoadFileIdentityService` sample call: 
```
work_file_path = "/data/spec/dummy/../fixtures/3t945r08v"
service = Hyrax::Migrator::Services::LoadFileIdentityService.new(work_file_path)
service.content_file_checksums
=> [{:file_name=>"3t945r08v_content.jpeg", :checksum=>"c1249a0e4d7c8cf64f5de6892681287e34a87b10", :checksum_encoding=>"sha1"}, {:file_name=>"3t945r08v_content.jpeg", :checksum=>"cd36b025f4393ace2caa47c6e65f25ed", :checksum_encoding=>"md5"}]
```
