### PR TITLE
skip file upload when no content found

### DIFF
--- a/app/actors/hyrax/migrator/actors/file_upload_actor.rb
+++ b/app/actors/hyrax/migrator/actors/file_upload_actor.rb
@@ -58,7 +58,7 @@ module Hyrax::Migrator::Actors
     end
 
     def handle_no_content_found(file_hash)
-      if config.content_file_can_be_nil == true
+      if config.content_file_can_be_nil.to_s == 'true'
         Rails.logger.warn "Skipping file upload for #{@work.pid}. No content found."
         return file_hash
       end

--- a/app/services/hyrax/migrator/services/file_upload_service.rb
+++ b/app/services/hyrax/migrator/services/file_upload_service.rb
@@ -101,8 +101,8 @@ module Hyrax
         Aws::Credentials.new(@aws_s3_app_key, @aws_s3_app_secret)
       end
 
-      def log_and_skip(message)
-        Rails.logger.warn "could not find a content file in #{message}"
+      def log_and_skip(data_dir)
+        Rails.logger.warn "could not find a content file in #{data_dir}"
         nil
       end
 

--- a/app/services/hyrax/migrator/services/file_upload_service.rb
+++ b/app/services/hyrax/migrator/services/file_upload_service.rb
@@ -40,24 +40,27 @@ module Hyrax
       private
 
       def upload_to_file_system
-        bytes_copied = copy_local_file
+        content = content_file
+        return local_file_obj(nil) unless content.present?
+
+        bytes_copied = copy_local_file(content)
         raise StandardError, "Expected #{File.size(dest_local_file)} bytes, received #{bytes_copied} bytes" unless File.size(dest_local_file) == bytes_copied
 
-        local_file_obj
+        local_file_obj(dest_local_file)
       rescue StandardError => e
         log_and_raise("FileUploadService upload_to_file_system error: #{e.message} : #{e.backtrace}")
       end
 
-      def copy_local_file
-        IO.copy_stream(content_file, make_path_for(dest_local_file))
+      def copy_local_file(content)
+        IO.copy_stream(content, make_path_for(dest_local_file))
       end
 
       def dest_local_file
         File.join(file_system_path, File.basename(content_file))
       end
 
-      def local_file_obj
-        { 'local_filename' => dest_local_file }
+      def local_file_obj(filename)
+        { 'local_filename' => filename }
       end
 
       def make_path_for(file)
@@ -98,10 +101,15 @@ module Hyrax
         Aws::Credentials.new(@aws_s3_app_key, @aws_s3_app_secret)
       end
 
+      def log_and_skip(message)
+        Rails.logger.warn "could not find a content file in #{message}"
+        nil
+      end
+
       def content_file
         files = Dir.entries(@data_dir)
         file = files.find { |f| f.downcase.include?(CONTENT_FILE) }
-        raise StandardError, "could not find a content file in #{@data_dir}" unless file
+        return log_and_skip(@data_dir) unless file
 
         File.join(@data_dir, file)
       rescue Errno::ENOENT

--- a/lib/hyrax/migrator/configuration.rb
+++ b/lib/hyrax/migrator/configuration.rb
@@ -137,6 +137,12 @@ module Hyrax::Migrator
       @migration_user ||= nil
     end
 
+    # A switch to skip content files during file uploads
+    attr_writer :content_file_can_be_nil
+    def content_file_can_be_nil
+      @content_file_can_be_nil ||= false
+    end
+
     # A switch to temporarily disable flagging unmapped predicates
     attr_writer :skip_field_mode
     def skip_field_mode

--- a/spec/hyrax/migrator/actors/file_upload_actor_spec.rb
+++ b/spec/hyrax/migrator/actors/file_upload_actor_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe Hyrax::Migrator::Actors::FileUploadActor do
       'local_filename' => local_filename
     }
   end
+  let(:missing_local_file) do
+    {
+      'local_filename' => nil
+    }
+  end
 
   before do
     allow(actor).to receive(:config).and_return(config)
@@ -68,6 +73,27 @@ RSpec.describe Hyrax::Migrator::Actors::FileUploadActor do
       it 'sets the uploaded_files attribute' do
         actor.create(work)
         expect(work.env[:attributes][:uploaded_files]).to eq [hyrax_uploaded_file.id]
+      end
+      it 'calls the next actor' do
+        expect(terminal).to receive(:create)
+        actor.create(work)
+      end
+    end
+
+    context 'when the content file is missing' do
+      before do
+        allow(service).to receive(:upload_file_content).and_return(missing_local_file)
+        allow(actor).to receive(:user).and_return(current_user)
+        actor.next_actor = terminal
+      end
+
+      it 'updates the work' do
+        actor.create(work)
+        expect(work.aasm_state).to eq('file_upload_succeeded')
+      end
+      it 'skips file upload' do
+        actor.create(work)
+        expect(work.env[:attributes][:uploaded_files]).to be_nil
       end
       it 'calls the next actor' do
         expect(terminal).to receive(:create)

--- a/spec/hyrax/migrator/actors/file_upload_actor_spec.rb
+++ b/spec/hyrax/migrator/actors/file_upload_actor_spec.rb
@@ -80,10 +80,11 @@ RSpec.describe Hyrax::Migrator::Actors::FileUploadActor do
       end
     end
 
-    context 'when the content file is missing' do
+    context 'when the content file is missing and content_file_can_be_nil is true' do
       before do
         allow(service).to receive(:upload_file_content).and_return(missing_local_file)
         allow(actor).to receive(:user).and_return(current_user)
+        config.content_file_can_be_nil = true
         actor.next_actor = terminal
       end
 
@@ -97,6 +98,29 @@ RSpec.describe Hyrax::Migrator::Actors::FileUploadActor do
       end
       it 'calls the next actor' do
         expect(terminal).to receive(:create)
+        actor.create(work)
+      end
+    end
+
+    context 'when the content file is missing and content_file_can_be_nil is false' do
+      let(:error) { StandardError }
+
+      before do
+        allow(service).to receive(:upload_file_content).and_return(missing_local_file)
+        allow(actor).to receive(:user).and_return(current_user)
+        config.content_file_can_be_nil = false
+        actor.next_actor = terminal
+      end
+
+      it 'updates the work' do
+        actor.create(work)
+        expect(work.aasm_state).to eq('file_upload_failed')
+      end
+      it 'raises file not found error' do
+        expect { actor.send(:handle_uploaded_file, missing_local_file) }.to raise_error(error)
+      end
+      it 'does not call the next actor' do
+        expect(terminal).not_to receive(:create)
         actor.create(work)
       end
     end

--- a/spec/hyrax/migrator/configuration_spec.rb
+++ b/spec/hyrax/migrator/configuration_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Hyrax::Migrator::Configuration do
   it { expect(conf.model_crosswalk).to be_a String }
   it { expect(conf.migration_user).to be_a String }
   it { expect(conf.skip_field_mode).to be_in([true, false]) }
+  it { expect(conf.content_file_can_be_nil).to be_in([true, false]) }
 
   context 'when registering a model' do
     before do

--- a/spec/hyrax/migrator/services/file_upload_service_spec.rb
+++ b/spec/hyrax/migrator/services/file_upload_service_spec.rb
@@ -64,8 +64,13 @@ RSpec.describe Hyrax::Migrator::Services::FileUploadService do
         stub_const('Hyrax::Migrator::Services::FileUploadService::CONTENT_FILE', 'invalid')
       end
 
-      it 'raises file not found error' do
-        expect { service.send(:content_file) }.to raise_error(StandardError, "could not find a content file in #{work.file_path}/data")
+      it 'logs a warning' do
+        expect(Rails.logger).to receive(:warn)
+        service.send(:content_file)
+      end
+
+      it 'returns nil' do
+        expect(service.send(:content_file)).to be_nil
       end
     end
 


### PR DESCRIPTION
fixes #149 

Instead of failing the actor stack, it now sends a warning to the logs that the content was not found and continues the stack given that `config.content_file_can_be_nil` is set to `true` in the configuration. 

If `config.content_file_can_be_nil` is `false`, it raises a file-not-found error.