### PR TITLE
Preflight metadata

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,5 +57,8 @@ RSpec/LetSetup:
 RSpec/MessageSpies:
   Enabled: false
 
+RSpec/NestedGroups:
+  Enabled: false
+
 Metrics/LineLength:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - 'bin/**/*'
     - 'Gemfile'
     - 'Rakefile'
+    - 'spec/support/rake.rb'
 
 Metrics/BlockLength:
   ExcludedMethods: ['included']
@@ -45,6 +46,7 @@ RSpec/DescribeClass:
   Exclude:
     - 'spec/system/**/*'
     - 'spec/views/**/*'
+    - 'spec/tasks/**/*'
 
 RSpec/LetSetup:
   Enabled: false

--- a/app/services/hyrax/migrator/services/crosswalk_metadata_service.rb
+++ b/app/services/hyrax/migrator/services/crosswalk_metadata_service.rb
@@ -10,13 +10,15 @@ module Hyrax::Migrator::Services
       @skip_field_mode = migrator_config.skip_field_mode
       @crosswalk_metadata_file = @config.crosswalk_metadata_file
       @crosswalk_overrides_file = @config.crosswalk_overrides_file
+      @result = {}
       @errors = []
     end
 
     # returns result hash
     def crosswalk
       super
-      @result[:errors] = @errors unless @errors.empty? || @result.blank?
+    ensure
+      @result[:errors] = @errors unless @errors.empty?
       @result
     end
 
@@ -32,10 +34,9 @@ module Hyrax::Migrator::Services
       result = super
       return result unless result.nil?
 
-      if @skip_field_mode
-        @errors << "Predicate not found: #{predicate} during crosswalk for #{@work.pid}"
-        return nil
-      end
+      @errors << "Predicate not found: #{predicate} during crosswalk for #{@work.pid}"
+      return nil if @skip_field_mode
+
       raise PredicateNotFoundError, predicate
     end
 

--- a/app/services/hyrax/migrator/services/crosswalk_metadata_service.rb
+++ b/app/services/hyrax/migrator/services/crosswalk_metadata_service.rb
@@ -15,16 +15,7 @@ module Hyrax::Migrator::Services
 
     # returns result hash
     def crosswalk
-      graph = create_graph
-      graph.statements.each do |statement|
-        data = lookup(statement.predicate.to_s)
-        next if data.nil?
-
-        processed_obj = process(data, statement.object)
-        next if processed_obj.nil?
-
-        assemble_hash(data, processed_obj)
-      end
+      super
       @result[:errors] = @errors unless @errors.empty? || @result.blank?
       @result
     end

--- a/app/services/hyrax/migrator/services/crosswalk_metadata_service.rb
+++ b/app/services/hyrax/migrator/services/crosswalk_metadata_service.rb
@@ -1,17 +1,15 @@
 # frozen_string_literal:true
 
-require 'rdf'
-require 'rdf/ntriples'
-require 'uri'
-
 module Hyrax::Migrator::Services
   # Called by the CrosswalkMetadataActor to map OD1 metadata to OD2
-  class CrosswalkMetadataService
+  class CrosswalkMetadataService < Hyrax::Migrator::CrosswalkMetadata
     def initialize(work, migrator_config)
       @work = work
       @data_dir = File.join(work.working_directory, 'data')
       @config = migrator_config
       @skip_field_mode = migrator_config.skip_field_mode
+      @crosswalk_metadata_file = @config.crosswalk_metadata_file
+      @crosswalk_overrides_file = @config.crosswalk_overrides_file
       @errors = []
     end
 
@@ -38,28 +36,10 @@ module Hyrax::Migrator::Services
       Hyrax::Migrator::Services::CreateGraphService.call(@data_dir)
     end
 
-    # Given property data and an object, adds them to result hash
-    def assemble_hash(data, object)
-      return if data[:property].blank?
-
-      @result ||= {}
-      if data[:multiple]
-        @result[data[:property].to_sym] ||= []
-        @result[data[:property].to_sym] += [object]
-      else
-        @result[data[:property].to_sym] = object
-      end
-    end
-
-    def find(predicate)
-      proc { |k| k[:predicate].casecmp(predicate).zero? }
-    end
-
     # Given an OD2 predicate, returns associated property data or nil
     def lookup(predicate)
-      hash = crosswalk_hash
-      result = hash.select(&find(predicate))
-      return result.first unless result.empty?
+      result = super
+      return result unless result.nil?
 
       if @skip_field_mode
         @errors << "Predicate not found: #{predicate} during crosswalk for #{@work.pid}"
@@ -68,35 +48,11 @@ module Hyrax::Migrator::Services
       raise PredicateNotFoundError, predicate
     end
 
-    # Given property data and an OD1 object, returns either the object, or a modified object
-    def process(data, object)
-      data[:function].blank? ? object.to_s : send(data[:function].to_sym, object.to_s)
-    end
-
-    # Returns a hash that maps OD2 predicates to OD2 properties and other data needed to process each field.
-    def crosswalk_hash
-      unique = crosswalk_data.reject { |x| crosswalk_overrides.one?(&find(x[:predicate])) }
-      @crosswalk_hash ||= crosswalk_overrides + unique
-    end
-
-    def crosswalk_data
-      @crosswalk_data ||= YAML.load_file(@config.crosswalk_metadata_file).deep_symbolize_keys
-      @crosswalk_data[:crosswalk]
-    end
-
-    def crosswalk_overrides
-      @crosswalk_overrides ||= YAML.load_file(@config.crosswalk_overrides_file).deep_symbolize_keys
-      @crosswalk_overrides[:overrides]
-    end
-
-    def return_nil(_object)
-      nil
-    end
-
     ##
     # Generate the data necessary for a Rails nested attribute
     def attributes_data(object)
-      return { 'id' => object.to_s, '_destroy' => 0 } unless valid_uri(object.to_s).nil?
+      result = super
+      return result unless result.nil?
 
       @errors << "Invalid URI #{object} found in crosswalk of #{@work.pid}"
       return nil if @skip_field_mode
@@ -123,17 +79,5 @@ module Hyrax::Migrator::Services
       return object.to_s unless valid_uri(object.to_s).nil?
     end
     # :nocov:
-
-    def valid_uri(uri)
-      uri =~ URI.regexp(%w[http https])
-    end
-
-    # Raise in lookup
-    class PredicateNotFoundError < StandardError
-    end
-
-    # Use in object modifying functions, identify object in message
-    class ModifyObjectFailedError < StandardError
-    end
   end
 end

--- a/lib/hyrax/migrator/crosswalk_metadata.rb
+++ b/lib/hyrax/migrator/crosswalk_metadata.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal:true
+
+require 'rdf'
+require 'rdf/ntriples'
+require 'uri'
+
+module Hyrax::Migrator
+  # Methods for mapping OD1 metadata to OD2
+  class CrosswalkMetadata
+    def initialize(crosswalk_metadata_file, crosswalk_overrides_file)
+      @crosswalk_metadata_file = crosswalk_metadata_file
+      @crosswalk_overrides_file = crosswalk_overrides_file
+    end
+
+    def crosswalk
+      graph = create_graph
+      graph.statements.each do |statement|
+        data = lookup(statement.predicate.to_s)
+        next if data.nil?
+
+        processed_obj = process(data, statement.object)
+        next if processed_obj.nil?
+
+        assemble_hash(data, processed_obj)
+      end
+      @result
+    end
+
+    # Given property data and an object, adds them to result hash
+    def assemble_hash(data, object)
+      return if data[:property].blank?
+
+      @result ||= {}
+      if data[:multiple]
+        @result[data[:property].to_sym] ||= []
+        @result[data[:property].to_sym] += [object]
+      else
+        @result[data[:property].to_sym] = object
+      end
+    end
+
+    def create_graph; end
+
+    def find(predicate)
+      proc { |k| k[:predicate].casecmp(predicate).zero? }
+    end
+
+    # Given an OD2 predicate, returns associated property data or nil
+    def lookup(predicate)
+      hash = crosswalk_hash
+      result = hash.select(&find(predicate))
+      return result.first unless result.empty?
+    end
+
+    # Given property data and an OD1 object, returns either the object, or a modified object
+    def process(data, object)
+      data[:function].blank? ? object.to_s : send(data[:function].to_sym, object.to_s)
+    end
+
+    # Returns a hash that maps OD2 predicates to OD2 properties and other data needed to process each field.
+    def crosswalk_hash
+      unique = crosswalk_data.reject { |x| crosswalk_overrides.one?(&find(x[:predicate])) }
+      @crosswalk_hash ||= crosswalk_overrides + unique
+    end
+
+    def crosswalk_data
+      @crosswalk_data ||= YAML.load_file(@crosswalk_metadata_file).deep_symbolize_keys
+      @crosswalk_data[:crosswalk]
+    end
+
+    def crosswalk_overrides
+      @crosswalk_overrides ||= YAML.load_file(@crosswalk_overrides_file).deep_symbolize_keys
+      @crosswalk_overrides[:overrides]
+    end
+
+    def return_nil(_object)
+      nil
+    end
+
+    ##
+    # Generate the data necessary for a Rails nested attribute
+    def attributes_data(object)
+      return { 'id' => object.to_s, '_destroy' => 0 } unless valid_uri(object.to_s).nil?
+    end
+
+    def valid_uri(uri)
+      uri =~ URI.regexp(%w[http https])
+    end
+
+    # Raise in lookup
+    class PredicateNotFoundError < StandardError
+    end
+
+    # Use in object modifying functions, identify object in message
+    class ModifyObjectFailedError < StandardError
+    end
+  end
+end

--- a/lib/hyrax/migrator/crosswalk_metadata.rb
+++ b/lib/hyrax/migrator/crosswalk_metadata.rb
@@ -7,6 +7,7 @@ require 'uri'
 module Hyrax::Migrator
   # Methods for mapping OD1 metadata to OD2
   class CrosswalkMetadata
+    attr_reader :result
     def initialize(crosswalk_metadata_file, crosswalk_overrides_file)
       @crosswalk_metadata_file = crosswalk_metadata_file
       @crosswalk_overrides_file = crosswalk_overrides_file

--- a/lib/tasks/preflight_tools/metadata_preflight.rake
+++ b/lib/tasks/preflight_tools/metadata_preflight.rake
@@ -6,16 +6,15 @@
 # To use: rake preflight_tools:metadata_preflight workdir=/data1/batch/some_dir pidlist=list.txt
 # If verbose=true then the attributes will be displayed
 
-require 'hyrax/migrator/crosswalk_metadata'
-
 namespace :preflight_tools do
   desc 'for migration preflight check of metadata'
   task metadata_preflight: :environment do
+    require 'hyrax/migrator/crosswalk_metadata'
     init
     pids.each do |pid|
       @errors << "Working on #{pid}..."
       attributes = crosswalk(GenericAsset.find(pid))
-      verbose(attributes) if ENV.include? 'verbose'
+      verbose_display(pid, attributes) if ENV.include? 'verbose'
     end
     write_errors
     @report.close
@@ -27,6 +26,7 @@ def pids
   File.readlines(File.join(@work_dir, ENV['pidlist'])).each do |line|
     pids << line.strip
   end
+  pids
 end
 
 def init
@@ -45,7 +45,8 @@ def crosswalk_file
   File.join(@work_dir, 'crosswalk.yml')
 end
 
-def verbose(attributes)
+def verbose_display(pid, attributes)
+  puts "Attributes for #{pid}..."
   attributes.each do |attr|
     puts attr.to_s
   end
@@ -69,12 +70,12 @@ def crosswalk(item)
 
     @service.assemble_hash(data, processed_obj)
   end
-  @result
+  @service.result
 end
 
 # Load the nt file and return graph
 def create_graph(item)
-  RDF::Graph.load(item.datastreams['descMetadata'])
+  item.datastreams['descMetadata'].graph
 end
 
 # Given an OD2 predicate, returns associated property data or nil

--- a/lib/tasks/preflight_tools/metadata_preflight.rake
+++ b/lib/tasks/preflight_tools/metadata_preflight.rake
@@ -1,0 +1,97 @@
+# frozen_string_literal:true
+
+# Requires a work dir with copies of crosswalk and overrides yml files
+# Also a list of pids in the work_dir, one pid per line
+# Will write a report of any errors found to the work dir
+# To use: rake preflight_tools:metadata_preflight workdir=/data1/batch/some_dir pidlist=list.txt
+# If verbose=true then the attributes will be displayed
+
+require 'hyrax/migrator/crosswalk_metadata'
+
+namespace :preflight_tools do
+  desc 'for migration preflight check of metadata'
+  task metadata_preflight: :environment do
+    init
+    pids.each do |pid|
+      @errors << "Working on #{pid}..."
+      attributes = crosswalk(GenericAsset.find(pid))
+      verbose(attributes) if ENV.include? 'verbose'
+    end
+    write_errors
+    @report.close
+  end
+end
+
+def pids
+  pids = []
+  File.readlines(File.join(@work_dir, ENV['pidlist'])).each do |line|
+    pids << line.strip
+  end
+end
+
+def init
+  @work_dir = ENV['work_dir']
+  datetime_today = Time.now.strftime('%Y%m%d%H%M%S') # "20171021125903"
+  @report = File.open(File.join(@work_dir, "report_#{datetime_today}.txt"), 'w')
+  @service = Hyrax::Migrator::CrosswalkMetadata.new(crosswalk_file, crosswalk_overrides_file)
+  @errors = []
+end
+
+def crosswalk_overrides_file
+  File.join(@work_dir, 'crosswalk_overrides.yml')
+end
+
+def crosswalk_file
+  File.join(@work_dir, 'crosswalk.yml')
+end
+
+def verbose(attributes)
+  attributes.each do |attr|
+    puts attr.to_s
+  end
+end
+
+def write_errors
+  @errors.each do |e|
+    @report.puts e
+  end
+end
+
+# returns result hash
+def crosswalk(item)
+  graph = create_graph(item)
+  graph.statements.each do |statement|
+    data = lookup(statement.predicate.to_s)
+    next if data.nil?
+
+    processed_obj = @service.process(data, statement.object)
+    next if processed_obj.nil?
+
+    @service.assemble_hash(data, processed_obj)
+  end
+  @result
+end
+
+# Load the nt file and return graph
+def create_graph(item)
+  RDF::Graph.load(item.datastreams['descMetadata'])
+end
+
+# Given an OD2 predicate, returns associated property data or nil
+def lookup(predicate)
+  result = @service.lookup(predicate)
+  return result unless result.nil?
+
+  @errors << "Predicate not found: #{predicate} during crosswalk"
+  nil
+end
+
+##
+# Generate the data necessary for a Rails nested attribute
+def attributes_data(object)
+  result = @service.attributes_data(object)
+  return result unless result.nil?
+
+  @errors << "Invalid URI #{object} found in crosswalk of #{@work.pid}"
+  nil
+end

--- a/spec/fixtures/pidlist
+++ b/spec/fixtures/pidlist
@@ -1,0 +1,2 @@
+abcde1234
+abcde5678

--- a/spec/hyrax/migrator/crosswalk_metadata_spec.rb
+++ b/spec/hyrax/migrator/crosswalk_metadata_spec.rb
@@ -12,17 +12,17 @@ RSpec.describe Hyrax::Migrator::CrosswalkMetadata do
     g
   end
   let(:rdfsubject) { RDF::URI('http://oregondigital.org/resource/oregondigital:abcde1234') }
-  let(:predicate_str) { 'http://purl.org/dc/elements/1.1/creator' }
+  let(:predicate_str) { 'http://purl.org/dc/terms/title' }
   let(:predicate) { RDF::URI(predicate_str) }
-  let(:object) { RDF::URI('http://id.loc.gov/authorities/names/nr93013379') }
-  let(:data) { { property: 'creator', predicate: predicate_str, multiple: true } }
+  let(:object) { RDF::Literal('String Cheese Theory') }
+  let(:data) { { property: 'title', predicate: predicate_str, multiple: true } }
   let(:pid) { '3t945r08v' }
   let(:crosswalk_metadata_file) { File.join(Rails.root, '..', 'fixtures', 'crosswalk.yml') }
   let(:crosswalk_overrides_file) { File.join(Rails.root, '..', 'fixtures', 'crosswalk_overrides.yml') }
   let(:file_path) { File.join(Rails.root, '..', 'fixtures', pid) }
   let(:work) { create(:work, pid: pid, file_path: file_path) }
   let(:service) { described_class.new(crosswalk_metadata_file, crosswalk_overrides_file) }
-  let(:result_hash) { { creator: [object.to_s] } }
+  let(:result_hash) { { title: [object.to_s] } }
   let(:predicate2_str) { 'http://opaquenamespace.org/ns/fullText' }
   let(:object2) { RDF::Literal('my little pony') }
   let(:data2) { { predicate: predicate2_str, function: 'return_nil' } }
@@ -87,14 +87,14 @@ RSpec.describe Hyrax::Migrator::CrosswalkMetadata do
   end
 
   describe 'process' do
-    context 'when given a property hash that does not contain a function' do
+    context 'when given a property hash that does not have a function' do
       it 'returns the object' do
         expect(service.send(:process, data, object)).to eq(object.to_s)
       end
     end
 
     context 'when given a property hash that does have a function' do
-      it 'modifies the object' do
+      it 'returns the function output' do
         expect(service.send(:process, data2, object2)).to eq(nil)
       end
     end
@@ -102,30 +102,40 @@ RSpec.describe Hyrax::Migrator::CrosswalkMetadata do
 
   describe 'crosswalk' do
     before do
-      graph << RDF::Statement.new(rdf_subject, RDF::URI('http://badpredicate.org'),RDF::Literal('bad'))
-      graph << RDF::Statement.new(rdf_subject, predicate, RDF::Literal('still bad'))
       allow(service).to receive(:create_graph).and_return(graph)
     end
 
     context 'when there is an nt to process' do
       it 'processes the statements and returns a result hash' do
         response = service.crosswalk
-        expect(response[:creator]).to eq([object.to_s])
+        expect(response[:title]).to eq([object.to_s])
       end
     end
 
     context 'when there is no value for a predicate' do
+      before do
+        graph << RDF::Statement.new(rdfsubject, RDF::URI('http://badpredicate.org'), RDF::Literal('bad'))
+        allow(service).to receive(:create_graph).and_return(graph)
+      end
+
       it 'skips it' do
         response = service.crosswalk
-        expect(response).to eq([object.to_s])
+        expect(response[:title]).to eq([object.to_s])
       end
     end
 
     context 'when there is no value returned from process' do
+      let(:predicate_str2) { 'http://purl.org/dc/terms/format' }
+      let(:predicate2) { RDF::URI(predicate_str2) }
+
+      before do
+        graph << RDF::Statement.new(rdfsubject, predicate2, RDF::Literal('still bad'))
+        allow(service).to receive(:create_graph).and_return(graph)
+      end
+
       it 'skips it' do
         response = service.crosswalk
-        expect(response[:creator]).to eq([object.to_s])
-        end
+        expect(response[:title]).to eq([object.to_s])
       end
     end
 
@@ -172,7 +182,7 @@ RSpec.describe Hyrax::Migrator::CrosswalkMetadata do
 
       it 'keeps calm and carries on' do
         response = service.crosswalk
-        expect(response.keys).to eq([:creator])
+        expect(response.keys).to eq([:title])
       end
     end
   end

--- a/spec/hyrax/migrator/crosswalk_metadata_spec.rb
+++ b/spec/hyrax/migrator/crosswalk_metadata_spec.rb
@@ -173,6 +173,7 @@ RSpec.describe Hyrax::Migrator::CrosswalkMetadata do
     it 'transforms the object using the function' do
       expect(service.crosswalk[:format_attributes]).to eq [{ '_destroy' => 0, 'id' => 'http://test/test' }]
     end
+
     context 'when object is a string rather than a uri' do
       let(:object) { 'blah blah' }
 

--- a/spec/hyrax/migrator/crosswalk_metadata_spec.rb
+++ b/spec/hyrax/migrator/crosswalk_metadata_spec.rb
@@ -102,6 +102,8 @@ RSpec.describe Hyrax::Migrator::CrosswalkMetadata do
 
   describe 'crosswalk' do
     before do
+      graph << RDF::Statement.new(rdf_subject, RDF::URI('http://badpredicate.org'),RDF::Literal('bad'))
+      graph << RDF::Statement.new(rdf_subject, predicate, RDF::Literal('still bad'))
       allow(service).to receive(:create_graph).and_return(graph)
     end
 
@@ -109,6 +111,21 @@ RSpec.describe Hyrax::Migrator::CrosswalkMetadata do
       it 'processes the statements and returns a result hash' do
         response = service.crosswalk
         expect(response[:creator]).to eq([object.to_s])
+      end
+    end
+
+    context 'when there is no value for a predicate' do
+      it 'skips it' do
+        response = service.crosswalk
+        expect(response).to eq([object.to_s])
+      end
+    end
+
+    context 'when there is no value returned from process' do
+      it 'skips it' do
+        response = service.crosswalk
+        expect(response[:creator]).to eq([object.to_s])
+        end
       end
     end
 

--- a/spec/hyrax/migrator/crosswalk_metadata_spec.rb
+++ b/spec/hyrax/migrator/crosswalk_metadata_spec.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require 'rdf'
+require 'uri'
+require 'hyrax/migrator/crosswalk_metadata'
+
+RSpec.describe Hyrax::Migrator::CrosswalkMetadata do
+  let(:graph) do
+    g = RDF::Graph.new
+    s = RDF::Statement.new(RDF::URI(rdfsubject), RDF::URI(predicate), RDF::URI(object))
+    g << s
+    g
+  end
+  let(:rdfsubject) { RDF::URI('http://oregondigital.org/resource/oregondigital:abcde1234') }
+  let(:predicate_str) { 'http://purl.org/dc/elements/1.1/creator' }
+  let(:predicate) { RDF::URI(predicate_str) }
+  let(:object) { RDF::URI('http://id.loc.gov/authorities/names/nr93013379') }
+  let(:data) { { property: 'creator', predicate: predicate_str, multiple: true } }
+  let(:pid) { '3t945r08v' }
+  let(:crosswalk_metadata_file) { File.join(Rails.root, '..', 'fixtures', 'crosswalk.yml') }
+  let(:crosswalk_overrides_file) { File.join(Rails.root, '..', 'fixtures', 'crosswalk_overrides.yml') }
+  let(:file_path) { File.join(Rails.root, '..', 'fixtures', pid) }
+  let(:work) { create(:work, pid: pid, file_path: file_path) }
+  let(:service) { described_class.new(crosswalk_metadata_file, crosswalk_overrides_file) }
+  let(:result_hash) { { creator: [object.to_s] } }
+  let(:predicate2_str) { 'http://opaquenamespace.org/ns/fullText' }
+  let(:object2) { RDF::Literal('my little pony') }
+  let(:data2) { { predicate: predicate2_str, function: 'return_nil' } }
+  let(:predicate2) { RDF::URI(predicate2_str) }
+  let(:data3) { { property: 'resource_type', predicate: 'http://my_little_pred', multiple: false } }
+
+  describe 'assemble_hash' do
+    context 'when given a property and an object' do
+      it 'adds the property and object to the result' do
+        service.send(:assemble_hash, data, object.to_s)
+        expect(service.instance_variable_get(:@result)).to eq(result_hash)
+      end
+    end
+
+    context 'when given a property that takes only single values' do
+      it 'does not put the object in an array' do
+        service.send(:assemble_hash, data3, object2.to_s)
+        expect(service.instance_variable_get(:@result)[:resource_type]).not_to be(Array)
+      end
+    end
+  end
+
+  describe 'crosswalk_hash' do
+    context 'when the lookup files exist' do
+      it 'loads the OD2 properties into an array of hashes' do
+        expect(service.send(:crosswalk_hash)).to include(data)
+      end
+      it 'loads the override predicates into the array of hashes' do
+        expect(service.send(:crosswalk_hash)).to include(data2)
+      end
+    end
+
+    context 'when a predicate is in both files' do
+      let(:overrides) { [{ property: 'rights-statement', predicate: 'http://purl.org/dc/terms/rights', multiple: false }] }
+
+      before do
+        allow(service).to receive(:crosswalk_overrides).and_return(overrides)
+      end
+
+      it 'favors overrides' do
+        p = service.send(:find, 'http://purl.org/dc/terms/rights')
+        result = service.send(:crosswalk_hash)
+        expect(result.select(&p).size).to eq(1)
+      end
+    end
+  end
+
+  describe 'lookup' do
+    context 'when given a predicate' do
+      it 'returns the associated property hash' do
+        expect(service.send(:lookup, predicate_str)).to eq data
+      end
+    end
+
+    context 'when given a predicate that is not in the config' do
+      let(:bad_predicate) { 'http://example.org/ns/iDontExist' }
+
+      it 'returns nil' do
+        expect(service.send(:lookup, bad_predicate)).to eq(nil)
+      end
+    end
+  end
+
+  describe 'process' do
+    context 'when given a property hash that does not contain a function' do
+      it 'returns the object' do
+        expect(service.send(:process, data, object)).to eq(object.to_s)
+      end
+    end
+
+    context 'when given a property hash that does have a function' do
+      it 'modifies the object' do
+        expect(service.send(:process, data2, object2)).to eq(nil)
+      end
+    end
+  end
+
+  describe 'crosswalk' do
+    before do
+      allow(service).to receive(:create_graph).and_return(graph)
+    end
+
+    context 'when there is an nt to process' do
+      it 'processes the statements and returns a result hash' do
+        response = service.crosswalk
+        expect(response[:creator]).to eq([object.to_s])
+      end
+    end
+
+    context 'when there is an nt with set and primary_set to process' do
+      let(:set_statement) do
+        RDF::Statement.new(
+          RDF::URI('http://oregondigital.org/resource/oregondigital:abcde1234'),
+          RDF::URI('http://opaquenamespace.org/ns/set'),
+          RDF::URI('http://oregondigital.org/resource/oregondigital:osu-scarc')
+        )
+      end
+
+      let(:primary_set_statement) do
+        RDF::Statement.new(
+          RDF::URI('http://oregondigital.org/resource/oregondigital:abcde1234'),
+          RDF::URI('http://opaquenamespace.org/ns/primarySet'),
+          RDF::URI('http://oregondigital.org/resource/oregondigital:osu-baseball')
+        )
+      end
+
+      let(:creator_statement) { RDF::Statement.new(RDF::URI(rdfsubject), RDF::URI(predicate), RDF::URI(object)) }
+
+      let(:graph) do
+        g = RDF::Graph.new
+        g << set_statement
+        g << primary_set_statement
+        g << creator_statement
+        g
+      end
+
+      it 'excludes :set from result hash' do
+        expect(service.crosswalk[:set]).to be_nil
+      end
+
+      it 'excludes :primary_set from result hash' do
+        expect(service.crosswalk[:primary_set]).to be_nil
+      end
+    end
+
+    context 'when processing uses the nil function' do
+      before do
+        graph << RDF::Statement(rdfsubject, predicate2, object2)
+      end
+
+      it 'keeps calm and carries on' do
+        response = service.crosswalk
+        expect(response.keys).to eq([:creator])
+      end
+    end
+  end
+
+  context 'with attributes_data function' do
+    let(:predicate_str) { 'http://purl.org/dc/terms/format' }
+    let(:predicate) { RDF::URI(predicate_str) }
+    let(:object) { RDF::URI('http://test/test') }
+    let(:data) { { property: 'format_attributes', predicate: predicate_str, multiple: true, function: 'attributes_data' } }
+
+    before do
+      allow(service).to receive(:create_graph).and_return(graph)
+    end
+
+    it 'transforms the object using the function' do
+      expect(service.crosswalk[:format_attributes]).to eq [{ '_destroy' => 0, 'id' => 'http://test/test' }]
+    end
+    context 'when object is a string rather than a uri' do
+      let(:object) { 'blah blah' }
+
+      it 'handles it by returning nil' do
+        expect(service.crosswalk).to eq nil
+      end
+    end
+  end
+end

--- a/spec/hyrax/migrator/services/crosswalk_metadata_service_spec.rb
+++ b/spec/hyrax/migrator/services/crosswalk_metadata_service_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rdf'
 require 'uri'
+require 'hyrax/migrator/crosswalk_metadata'
 
 RSpec.describe Hyrax::Migrator::Services::CrosswalkMetadataService do
   let(:graph) do

--- a/spec/support/rake.rb
+++ b/spec/support/rake.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rake'
+
+# From Hyrax
+module RakeHelper
+  def load_rake_environment(files)
+    @rake = Rake::Application.new
+    Rake.application = @rake
+    Rake::Task.define_task(:environment)
+    files.each { |file| load file }
+  end
+
+  def run_task(task, arg = nil)
+    capture_stdout_stderr do
+      @rake[task].invoke(arg)
+    end
+  end
+
+  # saves original $stdout in variable
+  # set $stdout as local instance of StringIO
+  # yields to code execution
+  # returns the local instance of StringIO
+  # resets $stdout to original value
+  def capture_stdout_stderr
+    out = StringIO.new
+    err = StringIO.new
+    $stdout = out
+    $stderr = err
+    begin
+      yield
+    rescue SystemExit => e
+      puts "error = #{e.inspect}"
+    end
+    return "Output: #{out.string}\n Errors:#{err.string}"
+  ensure
+    $stdout = STDOUT
+    $stdout = STDERR
+  end
+
+  RSpec.configure do |config|
+    config.include RakeHelper
+  end
+end
+

--- a/spec/tasks/preflight_tools/rake_spec.rb
+++ b/spec/tasks/preflight_tools/rake_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rake'
+require 'pry'
+require 'rdf'
+require 'uri'
+require 'rdf/ntriples'
+require 'hyrax/migrator/crosswalk_metadata'
+
+class GenericAsset
+  def self.find(pid); end
+end
+
+RSpec.describe 'preflight_tools rake tasks' do
+  include ActiveJob::TestHelper
+  describe 'preflight_tools:metadata_preflight' do
+    let(:work) { double }
+    let(:nt) { 'spec/fixtures/3t945r08v/data/3t945r08v_descMetadata.nt' }
+    let(:graph) { RDF::Graph.load(nt) }
+    let(:run_rake_task) do
+      ENV['work_dir'] = 'spec/fixtures'
+      ENV['pidlist'] = 'pidlist'
+      Rake.application.invoke_task 'preflight_tools:metadata_preflight'
+    end
+
+    before do
+      load_rake_environment [File.expand_path('../../../lib/tasks/preflight_tools/metadata_preflight.rake', __dir__), File.expand_path('../../../lib/hyrax/migrator/crosswalk_metadata.rb', __dir__)]
+      allow(GenericAsset).to receive(:find).and_return(work)
+      allow(work).to receive(:datastreams).and_return(nt)
+      allow(RDF::Graph).to receive(:load).and_return(graph)
+      run_rake_task
+    end
+
+    after do
+      time = Time.now.strftime('%Y%m%d')
+      Dir.glob("spec/fixtures/report_#{time}*").each do |f|
+        File.delete(f)
+      end
+    end
+
+    context 'when there are errors' do
+      it 'writes them to a file' do
+        file = Dir.glob('spec/fixtures/report_*')
+        expect(IO.read(file.first)).to include('Predicate not found')
+      end
+    end
+  end
+end

--- a/spec/tasks/preflight_tools/rake_spec.rb
+++ b/spec/tasks/preflight_tools/rake_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe 'preflight_tools rake tasks' do
   describe 'preflight_tools:metadata_preflight' do
     let(:work) { double }
     let(:nt) { 'spec/fixtures/3t945r08v/data/3t945r08v_descMetadata.nt' }
+    let(:datastreams) { double }
+    let(:datastream) { double }
     let(:graph) { RDF::Graph.load(nt) }
     let(:run_rake_task) do
       ENV['work_dir'] = 'spec/fixtures'
@@ -27,8 +29,9 @@ RSpec.describe 'preflight_tools rake tasks' do
     before do
       load_rake_environment [File.expand_path('../../../lib/tasks/preflight_tools/metadata_preflight.rake', __dir__), File.expand_path('../../../lib/hyrax/migrator/crosswalk_metadata.rb', __dir__)]
       allow(GenericAsset).to receive(:find).and_return(work)
-      allow(work).to receive(:datastreams).and_return(nt)
-      allow(RDF::Graph).to receive(:load).and_return(graph)
+      allow(work).to receive(:datastreams).and_return(datastreams)
+      allow(datastreams).to receive(:[]).with('descMetadata').and_return(datastream)
+      allow(datastream).to receive(:graph).and_return(graph)
       run_rake_task
     end
 


### PR DESCRIPTION
partially fulfills #173 
For local OD1 testing of the preflight rake task, I did:
copy crosswalk_metadata.rb over to oregondigital/lib/hyrax/migrator/crosswalk_metadata.rb
copy metadata_preflight.rake to oregondigital/lib/tasks/preflight_tools/metadata_preflight.rake
 I enabled this line in oregondigital/config/application.rb
  config.autoload_paths += Dir["#{config.root}/lib/**/"]
Also requires a work directory (I used /oregondigital/preflight)
Copied crosswalk.yml and crosswalk_overrides.yml to the work directory
created a pid list for the work directory (one pid per line)
Then started up the containers, started a rails console session on server
bundle exec rake preflight_tools:metadata_preflight work_dir=/oregondigital/preflight pidlist=pidlist verbose=true
Currently puts a file of any metadata errors in the work directory and if verbose=true prints the attributes to screen.