### PR TITLE
raise model errors if any during create

### DIFF
--- a/lib/hyrax/migrator/hyrax_core/actor_stack.rb
+++ b/lib/hyrax/migrator/hyrax_core/actor_stack.rb
@@ -23,7 +23,11 @@ module Hyrax::Migrator
       # Cause the Hyrax actor stack to ingest this work
       # @return [Boolean] - true if create was successful, false if failed
       def create
-        actor.create(actor_environment)
+        status = actor.create(actor_environment)
+
+        raise StandardError, curation_concern.errors.full_messages.join(' ') if status == false
+
+        status
       rescue StandardError => e
         logger.error(e.message)
         raise e

--- a/spec/hyrax/migrator/hyrax_core/actor_stack_spec.rb
+++ b/spec/hyrax/migrator/hyrax_core/actor_stack_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Hyrax::Migrator::HyraxCore::ActorStack do
         allow(actor).to receive(:create).and_return(false)
       end
 
-      it { expect(actor_stack.create).to eq false }
+      it { expect { actor_stack.create }.to raise_error }
     end
   end
 

--- a/spec/hyrax/migrator/hyrax_core/actor_stack_spec.rb
+++ b/spec/hyrax/migrator/hyrax_core/actor_stack_spec.rb
@@ -32,10 +32,10 @@ RSpec.describe Hyrax::Migrator::HyraxCore::ActorStack do
 
     context 'when it fails' do
       before do
-        allow(actor).to receive(:create).and_return(false)
+        allow(actor).to receive(:create).and_raise('fail')
       end
 
-      it { expect { actor_stack.create }.to raise_error }
+      it { expect { actor_stack.create }.to raise_error('fail') }
     end
   end
 


### PR DESCRIPTION
fixes #184 

New error descriptions when fields are blank:
```
[ActiveJob] [Hyrax::Migrator::Jobs::MigrateWorkJob] [9d2127a1-9476-4461-8d16-1933760b30b3] df70sk17p failed while persisting work: failed persisting work df70sk17p, Resource type can't be blank : ["/usr/local/bundle/bundler/gems/hyrax-migrator-ab660e18c9b8/lib/hyrax/migrator/hyrax_core/actor_stack.rb:28:in `create'", "/usr/local/bundle/bundler/gems/hyrax-migrator-ab660e18c9b8/app/services/hyrax/migrator/services/persist_work_service.rb:18:in `persist_work'"
```