### PR TITLE
update rails with optimistic version constraint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       aws-sdk-s3
       bagit
       haml
-      rails (~> 5.2)
+      rails (>= 5.1.6)
       rdf
       rubyzip
       sidekiq
@@ -113,7 +113,7 @@ GEM
     jmespath (1.4.0)
     json (2.2.0)
     link_header (0.0.8)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -233,7 +233,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     tins (1.20.2)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.5.0)
     validatable (1.6.7)

--- a/hyrax-migrator.gemspec
+++ b/hyrax-migrator.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'aws-sdk-s3'
   s.add_dependency 'bagit'
   s.add_dependency 'haml'
-  s.add_dependency 'rails', '~> 5.2'
+  s.add_dependency 'rails', '>= 5.1.6'
   s.add_dependency 'rdf'
   s.add_dependency 'rubyzip'
   s.add_dependency 'sidekiq'


### PR DESCRIPTION
Currently getting dependency conflicts with hyrax gem:
```
app@6a9c89f9a773:~$ bundle update hyrax-migrator
Fetching https://github.com/OregonDigital/hyrax-migrator.git
Fetching gem metadata from https://rubygems.org/......
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies..........
Bundler could not find compatible versions for gem "rails":
  In Gemfile:
    rails (~> 5.1.6)

    hyrax-migrator was resolved to 0.1.0, which depends on
      rails (~> 5.2)
```
I think it got introduced in a recent update https://github.com/OregonDigital/hyrax-migrator/pull/192 to address https://github.com/OregonDigital/OD2/issues/1086

We could update the gem constraint to be optimistic so that we can force an upgrade of the gem to  newer versions of rails in OD2.

