### PR TITLE
Checksums profile

### DIFF
--- a/app/services/hyrax/migrator/services/verification_service.rb
+++ b/app/services/hyrax/migrator/services/verification_service.rb
@@ -15,7 +15,7 @@ module Hyrax::Migrator::Services
 
     def add_services
       @metadata_service = Hyrax::Migrator::Services::VerifyMetadataService.new(@work, @config, hyrax_asset, original_profile)
-      @checksums_service = Hyrax::Migrator::Services::VerifyChecksumsService.new(@work, hyrax_asset, original_profile)
+      @checksums_service = Hyrax::Migrator::Services::VerifyChecksumsService.new(hyrax_asset, @profile_dir)
       @derivatives_service = Hyrax::Migrator::Services::VerifyDerivativesService.new(hyrax_asset, original_profile)
       @children_service = Hyrax::Migrator::Services::VerifyChildrenService.new(@work, hyrax_asset, original_profile)
     end

--- a/app/services/hyrax/migrator/services/verify_checksums_service.rb
+++ b/app/services/hyrax/migrator/services/verify_checksums_service.rb
@@ -6,31 +6,18 @@ module Hyrax::Migrator::Services
   ##
   # A service to compare the checksums from the source asset and the migrated asset
   class VerifyChecksumsService
+    ALGORITHM = 'MD5hex'
+
     def initialize(hyrax_asset, profile_dir)
       @hyrax_asset = hyrax_asset
       @profile_dir = profile_dir
-      @new_profile = new_profile
-      @errors = []
     end
 
-    def content
-      fs = @hyrax_asset.file_sets.first
-      @content = fs.blank? ? '' : fs.original_file.content
-    end
-
-    def new_profile
-      result_hash = {}
-      result_hash[:checksums] = checksums
-      result_hash
-    end
-
-    def checksums
-      checksums = {}
-      checksums['SHA1hex'] = Digest::SHA1.hexdigest content
-      checksums['SHA1base64'] = Digest::SHA1.base64digest content
-      checksums['MD5hex'] = Digest::MD5.hexdigest content
-      checksums['MD5base64'] = Digest::MD5.base64digest content
-      checksums
+    ## Hyrax already calculates checksum using MD5hex
+    def new_content_checksum
+      @hyrax_asset.file_sets.first.original_file.original_checksum.first
+    rescue StandardError
+      ''
     end
 
     def original_checksums
@@ -42,12 +29,9 @@ module Hyrax::Migrator::Services
     def verify_content
       return [] if original_checksums['checksums'].blank?
 
-      original_checksums['checksums'].each do |key, val|
-        next if val.blank?
+      return ["Content does not match precomputed #{ALGORITHM} checksums for #{@hyrax_asset.id}."] unless original_checksums['checksums'][ALGORITHM].first == new_content_checksum
 
-        @errors << "Content does not match precomputed #{key} checksums for #{@hyrax_asset.id}." unless val.first == @new_profile[:checksums][key]
-      end
-      @errors
+      []
     end
   end
 end

--- a/spec/fixtures/data/df70jh899_checksums.yml
+++ b/spec/fixtures/data/df70jh899_checksums.yml
@@ -1,0 +1,10 @@
+checksums:
+  SHA1hex:
+  - f794b23c0c6fe1083d0ca8b58261a078cd968967
+  SHA1base64:
+  - 95SyPAxv4Qg9DKi1gmGgeM2WiWc=
+  MD5hex:
+  - 28da6259ae5707c68708192a40b3e85c
+  MD5base64:
+  - KNpiWa5XB8aHCBkqQLPoXA==
+

--- a/spec/fixtures/data/df70jh899_profile.yml
+++ b/spec/fixtures/data/df70jh899_profile.yml
@@ -2,15 +2,6 @@ sets:
   set:
   - oregondigital:joel-palmer
   primarySet: oregondigital:joel-palmer
-checksums:
-  SHA1hex:
-  - f794b23c0c6fe1083d0ca8b58261a078cd968967
-  SHA1base64:
-  - 95SyPAxv4Qg9DKi1gmGgeM2WiWc=
-  MD5hex:
-  - 28da6259ae5707c68708192a40b3e85c
-  MD5base64:
-  - KNpiWa5XB8aHCBkqQLPoXA==
 derivatives_info:
   has_thumbnail: false
   has_content_ocr: false

--- a/spec/hyrax/migrator/services/verify_checksums_service_spec.rb
+++ b/spec/hyrax/migrator/services/verify_checksums_service_spec.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Hyrax::Migrator::Services::VerifyChecksumsService do
-  let(:migrator_work) { double }
   let(:hyrax_work) { double }
-  let(:config) { Hyrax::Migrator::Configuration.new }
-  let(:original_profile) { YAML.load_file("spec/fixtures/data/#{pid}_profile.yml") }
-  let(:service) { described_class.new(migrator_work, hyrax_work, original_profile) }
+  let(:service) { described_class.new(hyrax_work, profile_dir) }
+  let(:profile_dir) { 'spec/fixtures/data' }
   let(:pid) { 'df70jh899' }
   let(:file_set) { instance_double('FileSet', id: 'bn999672v', uri: 'http://127.0.0.1/rest/fake/bn/99/96/72/bn999672v') }
   let(:content_path) { 'spec/fixtures/data/world.png' }
@@ -14,9 +12,9 @@ RSpec.describe Hyrax::Migrator::Services::VerifyChecksumsService do
   before do
     allow(Hyrax::Migrator::HyraxCore::Asset).to receive(:find).and_return(hyrax_work)
     allow(hyrax_work).to receive(:as_json).and_return(json)
-    allow(migrator_work).to receive(:pid).and_return(pid)
     allow(hyrax_work).to receive(:file_sets).and_return([file_set])
     allow(file_set).to receive(:original_file).and_return(original_file)
+    allow(hyrax_work).to receive(:id).and_return(pid)
   end
 
   describe 'verify_content' do
@@ -36,11 +34,9 @@ RSpec.describe Hyrax::Migrator::Services::VerifyChecksumsService do
       end
     end
 
-    context 'when the original profile does not have checksums' do
-      let(:original_profile) { instance_double('od_asset_profile', content: 'cpd has no content file') }
-
+    context 'when there were no checksums generated for the export' do
       before do
-        allow(original_profile).to receive(:[]).with('checksums').and_return nil
+        allow(YAML).to receive(:load_file).and_raise(Errno::ENOENT)
       end
 
       it 'returns no errors' do

--- a/spec/hyrax/migrator/services/verify_checksums_service_spec.rb
+++ b/spec/hyrax/migrator/services/verify_checksums_service_spec.rb
@@ -7,13 +7,15 @@ RSpec.describe Hyrax::Migrator::Services::VerifyChecksumsService do
   let(:pid) { 'df70jh899' }
   let(:file_set) { instance_double('FileSet', id: 'bn999672v', uri: 'http://127.0.0.1/rest/fake/bn/99/96/72/bn999672v') }
   let(:content_path) { 'spec/fixtures/data/world.png' }
-  let(:original_file) { instance_double('hyrax_original_file', content: File.open(content_path).read) }
+  let(:original_file) { double }
+  let(:original_checksum) { ['28da6259ae5707c68708192a40b3e85c'] }
 
   before do
     allow(Hyrax::Migrator::HyraxCore::Asset).to receive(:find).and_return(hyrax_work)
     allow(hyrax_work).to receive(:as_json).and_return(json)
     allow(hyrax_work).to receive(:file_sets).and_return([file_set])
     allow(file_set).to receive(:original_file).and_return(original_file)
+    allow(original_file).to receive(:original_checksum).and_return(original_checksum)
     allow(hyrax_work).to receive(:id).and_return(pid)
   end
 
@@ -27,9 +29,19 @@ RSpec.describe Hyrax::Migrator::Services::VerifyChecksumsService do
     end
 
     context 'when checksums do not match with migrated content (invalid)' do
-      let(:original_file) { instance_double('hyrax_original_file', content: 'invalid') }
+      let(:original_checksum) { ['invalid'] }
 
       it 'returns errors' do
+        expect(service.verify_content).to include(match(/Content does not match precomputed/))
+      end
+    end
+
+    context 'when there is a checksum profile but no hyrax file' do
+      before do
+        allow(original_checksum).to receive(:first).and_raise StandardError
+      end
+
+      it 'reports the mismatch' do
         expect(service.verify_content).to include(match(/Content does not match precomputed/))
       end
     end


### PR DESCRIPTION
fixes #248 
also discovered that calculating checksums for the uploaded hyrax asset was unnecessary; using the MD5hex calculated by hyrax to improve performance