### PR TITLE
Mktmpdir

### DIFF
--- a/app/models/concerns/hyrax/migrator/has_working_directory.rb
+++ b/app/models/concerns/hyrax/migrator/has_working_directory.rb
@@ -122,7 +122,7 @@ module Hyrax::Migrator
     end
 
     def temporary_directory(prefix)
-      Dir.mktmpdir([prefix, Time.now.to_i.to_s])
+      Dir.mktmpdir([prefix, Time.now.to_i.to_s], Hyrax::Migrator.config.file_system_path)
     end
   end
 end

--- a/app/services/hyrax/migrator/services/verification_service.rb
+++ b/app/services/hyrax/migrator/services/verification_service.rb
@@ -30,6 +30,7 @@ module Hyrax::Migrator::Services
       errors << @checksums_service.verify_content
       errors << @derivatives_service.verify
       errors << @children_service.verify_children
+      @work.remove_temp_directory
       errors
     rescue StandardError => e
       errors << "Encountered an error while working on #{@work.pid}: #{e.message}"

--- a/spec/hyrax/migrator/services/verification_service_spec.rb
+++ b/spec/hyrax/migrator/services/verification_service_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Hyrax::Migrator::Services::VerificationService do
 
   before do
     allow(migrator_work).to receive(:pid).and_return(pid)
+    allow(migrator_work).to receive(:remove_temp_directory)
     allow(Hyrax::Migrator::Services::VerifyMetadataService).to receive(:new).and_return(metadata_service)
     allow(Hyrax::Migrator::Services::VerifyChecksumsService).to receive(:new).and_return(checksums_service)
     allow(Hyrax::Migrator::Services::VerifyDerivativesService).to receive(:new).and_return(derivatives_service)

--- a/spec/hyrax/migrator/work_spec.rb
+++ b/spec/hyrax/migrator/work_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Hyrax::Migrator::Work do
 
   context 'with a temporary directory containing the unzipped file' do
     before do
+      Hyrax::Migrator.config.file_system_path = '/tmp'
       Zip::File.open(zip_file, Zip::File::CREATE) do |zipfile|
         zipfile.add('Gemfile', File.join(Rails.root, '../../Gemfile'))
       end


### PR DESCRIPTION
fixes #240
specifies what directory to use to temporarily unzip bag
cleans up temp directory left after verification service runs