### PR TITLE
Refactor main verification

### DIFF
--- a/spec/hyrax/migrator/services/verification_service_spec.rb
+++ b/spec/hyrax/migrator/services/verification_service_spec.rb
@@ -1,52 +1,32 @@
 # frozen_string_literal: true
 
 RSpec.describe Hyrax::Migrator::Services::VerificationService do
-  let(:migrator_work) { double }
-  let(:hyrax_work) { double }
-  let(:config) { Hyrax::Migrator::Configuration.new }
-  let(:original_profile) { YAML.load_file("spec/fixtures/data/#{pid}_profile.yml") }
-  let(:service) { described_class.new(migrator_work, config, 'spec/fixtures/data') }
-  let(:pid) { 'df70jh899' }
-  let(:metadata_service) { double }
-  let(:checksums_service) { double }
-  let(:derivatives_service) { double }
-  let(:children_service) { double }
+  let(:service) { described_class.new(pid, services) }
+  let(:pid) { 'abcde1234' }
+  let(:work) { double }
+  let(:asset) { double }
+  let(:working_dir) { 'path_to_somewhere' }
+  let(:original_profile) { double }
+  let(:services) { [Hyrax::Migrator::Services::VerifyVisibilityService] }
+  let(:visibility_service) { double }
+  let(:migrated_work) { MigratedWork.new(pid) }
+  let(:error_message) { 'there is an anomaly in the space-time continuum' }
 
   before do
-    allow(migrator_work).to receive(:pid).and_return(pid)
-    allow(migrator_work).to receive(:remove_temp_directory)
-    allow(Hyrax::Migrator::Services::VerifyMetadataService).to receive(:new).and_return(metadata_service)
-    allow(Hyrax::Migrator::Services::VerifyChecksumsService).to receive(:new).and_return(checksums_service)
-    allow(Hyrax::Migrator::Services::VerifyDerivativesService).to receive(:new).and_return(derivatives_service)
-    allow(Hyrax::Migrator::Services::VerifyChildrenService).to receive(:new).and_return(children_service)
-    allow(Hyrax::Migrator::HyraxCore::Asset).to receive(:find).and_return(hyrax_work)
+    allow(Hyrax::Migrator::Work).to receive(:find_by).and_return(work)
+    allow(Hyrax::Migrator::HyraxCore::Asset).to receive(:find).and_return(asset)
+    allow(work).to receive(:working_directory).and_return(working_dir)
+    allow(work).to receive(:pid).and_return(pid)
+    allow(YAML).to receive(:load_file).and_return(original_profile)
+    allow(Hyrax::Migrator::Services::VerifyVisibilityService).to receive(:new).and_return(visibility_service)
+    allow(visibility_service).to receive(:verify).and_return error_message
+    allow(work).to receive(:remove_temp_directory)
   end
 
-  describe 'verify' do
-    context 'when a service returns an error' do
-      before do
-        allow(metadata_service).to receive(:verify_metadata).and_return(["Unable to verify identifier in #{pid}."])
-        allow(checksums_service).to receive(:verify_content).and_return([])
-        allow(derivatives_service).to receive(:verify).and_return([])
-        allow(children_service).to receive(:verify_children).and_return([])
-      end
-
+  describe '#verify' do
+    context 'when a verifier returns an error' do
       it 'passes the error on' do
-        expect(service.verify).to eq([["Unable to verify identifier in #{pid}."], [], [], []])
-      end
-    end
-
-    context 'when an error is raised' do
-      let(:error) { StandardError }
-
-      before do
-        allow(metadata_service).to receive(:verify_metadata).and_return([])
-        allow(checksums_service).to receive(:verify_content).and_return([])
-        allow(derivatives_service).to receive(:verify).and_raise(error, 'Fail')
-      end
-
-      it 'handles the error' do
-        expect(service.verify).to eq([[], [], "Encountered an error while working on #{pid}: Fail"])
+        expect(service.verify).to eq([error_message])
       end
     end
   end

--- a/spec/hyrax/migrator/services/verification_service_spec.rb
+++ b/spec/hyrax/migrator/services/verification_service_spec.rb
@@ -7,10 +7,14 @@ RSpec.describe Hyrax::Migrator::Services::VerificationService do
   let(:asset) { double }
   let(:working_dir) { 'path_to_somewhere' }
   let(:original_profile) { double }
-  let(:services) { [Hyrax::Migrator::Services::VerifyVisibilityService] }
-  let(:visibility_service) { double }
+  let(:services) { [FakeService] }
+  let(:fake_service) { double }
   let(:migrated_work) { MigratedWork.new(pid) }
   let(:error_message) { 'there is an anomaly in the space-time continuum' }
+
+  class FakeService
+    def initialize(migrated_work); end
+  end
 
   before do
     allow(Hyrax::Migrator::Work).to receive(:find_by).and_return(work)
@@ -18,8 +22,8 @@ RSpec.describe Hyrax::Migrator::Services::VerificationService do
     allow(work).to receive(:working_directory).and_return(working_dir)
     allow(work).to receive(:pid).and_return(pid)
     allow(YAML).to receive(:load_file).and_return(original_profile)
-    allow(Hyrax::Migrator::Services::VerifyVisibilityService).to receive(:new).and_return(visibility_service)
-    allow(visibility_service).to receive(:verify).and_return error_message
+    allow(FakeService).to receive(:new).and_return(fake_service)
+    allow(fake_service).to receive(:verify).and_return error_message
     allow(work).to receive(:remove_temp_directory)
   end
 


### PR DESCRIPTION
This is some work to simplify the main verification service that calls all of the specific verifier services, ahead of adding visibility (see https://github.com/OregonDigital/hyrax-migrator/compare/add_visibility_verify, #247)
It packages up all of the objects used by the verifiers into a sub class MigratedWork
It requires that all of the individual verifiers take the same migrated_work as their initial argument, and that their action be named :verify, so that the services can be looped through.