### PR TITLE
Add visibility verify

### DIFF
--- a/app/services/hyrax/migrator/services/verify_service.rb
+++ b/app/services/hyrax/migrator/services/verify_service.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal:true
+
+module Hyrax::Migrator::Services
+  # Create report on facet values for migrated batch of assets
+  class VerifyService
+    def initialize(migrated_work)
+      @migrated_work = migrated_work
+    end
+
+    def verify; end
+  end
+end

--- a/app/services/hyrax/migrator/services/verify_visibility_service.rb
+++ b/app/services/hyrax/migrator/services/verify_visibility_service.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal:true
+
+module Hyrax::Migrator::Services
+  # A service to verify that the asset's visibility is correctly assigned
+  class VerifyVisibilityService < VerifyService
+    include Hyrax::Migrator::VisibilityMethods
+    def verify
+      return 'visibility error' if lookup(@migrated_work.original_profile['visibility'])[:visibility] != @migrated_work.asset.visibility
+
+      ''
+    end
+  end
+end

--- a/lib/hyrax/migrator.rb
+++ b/lib/hyrax/migrator.rb
@@ -17,6 +17,7 @@ require 'hyrax/migrator/hyrax_core/uploaded_file'
 require 'hyrax/migrator/hyrax_core/user'
 require 'hyrax/migrator/hyrax_core/derivative_path'
 require 'hyrax/migrator/crosswalk_metadata'
+require 'hyrax/migrator/visibility_methods'
 require 'hyrax/migrator/visibility_lookup'
 
 module Hyrax

--- a/lib/hyrax/migrator/visibility_lookup.rb
+++ b/lib/hyrax/migrator/visibility_lookup.rb
@@ -5,44 +5,12 @@ require 'nokogiri'
 module Hyrax::Migrator
   # A class to inspect the metadata and crosswalk the type to a model used for migration
   class VisibilityLookup
+    include Hyrax::Migrator::VisibilityMethods
     def lookup_visibility
       result = lookup(read_groups)
       return result if comparison_check(result)
 
       nil
-    end
-
-    private
-
-    # this should provide access to the read_groups metadata
-    # in preflight, use the item
-    # in the migrator use the workflow metadata
-    def read_groups; end
-
-    #  metadata field on asset.
-    # in preflight, use descMetadata
-    # in migrator, use work env attributes
-    def access_restrictions; end
-
-    def lookup(groups)
-      if groups.include? 'public'
-        { visibility: 'open' }
-      elsif groups.include? 'University-of-Oregon'
-        { visibility: 'uo' }
-      elsif groups.include? 'Oregon-State'
-        { visibility: 'osu' }
-      else
-        { visibility: 'restricted' }
-      end
-    end
-
-    def comparison_check(visibility)
-      unless access_restrictions.blank?
-        return true if visibility[:visibility] != 'open'
-
-        return false
-      end
-      true
     end
   end
 end

--- a/lib/hyrax/migrator/visibility_lookup_preflight.rb
+++ b/lib/hyrax/migrator/visibility_lookup_preflight.rb
@@ -9,10 +9,10 @@ module Hyrax::Migrator
     attr_accessor :work
 
     def lookup_visibility
-      result = lookup(read_groups)
-      return 'error: read_groups does not agree with access_restrictions' unless comparison_check(result)
+      result = super
+      return result unless result.nil?
 
-      result
+      'error: read_groups does not agree with access_restrictions'
     end
 
     private

--- a/lib/hyrax/migrator/visibility_methods.rb
+++ b/lib/hyrax/migrator/visibility_methods.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal:true
+
+module Hyrax::Migrator
+  # methods for Visibility lookup services
+  module VisibilityMethods
+    # this should provide access to the read_groups metadata
+    # in preflight, use the item
+    # in the migrator use the workflow metadata
+    def read_groups; end
+
+    #  metadata field on asset.
+    # in preflight, use descMetadata
+    # in migrator, use work env attributes
+    def access_restrictions; end
+
+    def lookup(groups)
+      if groups.include? 'public'
+        { visibility: 'open' }
+      elsif groups.include? 'University-of-Oregon'
+        { visibility: 'uo' }
+      elsif groups.include? 'Oregon-State'
+        { visibility: 'osu' }
+      else
+        { visibility: 'restricted' }
+      end
+    end
+
+    def comparison_check(visibility)
+      unless access_restrictions.blank?
+        return true if visibility[:visibility] != 'open'
+
+        return false
+      end
+      true
+    end
+  end
+end

--- a/spec/fixtures/data/df70jh899_profile.yml
+++ b/spec/fixtures/data/df70jh899_profile.yml
@@ -12,6 +12,8 @@ derivatives_info:
   has_pyramidal_image: false
   has_content_mp4: false
   has_content_jpg: false
+visibility:
+  - 'public'
 fields:
   title:
   - Letters

--- a/spec/hyrax/migrator/services/verify_visibility_service_spec.rb
+++ b/spec/hyrax/migrator/services/verify_visibility_service_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Migrator::Services::VerifyVisibilityService do
+  let(:asset) { double }
+  let(:original_profile) { YAML.load_file("spec/fixtures/data/#{pid}_profile.yml") }
+  let(:pid) { 'df70jh899' }
+  let(:service) { described_class.new(migrated_work) }
+  let(:migrated_work) { double }
+
+  before do
+    allow(Hyrax::Migrator::Services::VerificationService::MigratedWork).to receive(:new).and_return(migrated_work)
+    allow(migrated_work).to receive(:asset).and_return(asset)
+    allow(migrated_work).to receive(:original_profile).and_return(original_profile)
+  end
+
+  context 'when visibility of hyrax asset matches the profile' do
+    before do
+      allow(asset).to receive(:visibility).and_return('open')
+    end
+
+    it 'returns empty' do
+      expect(service.verify).to eq('')
+    end
+  end
+
+  context 'when visibility of hyrax asset does not match profile' do
+    before do
+      allow(asset).to receive(:visibility).and_return('uo')
+    end
+
+    it 'returns an error' do
+      expect(service.verify).to eq('visibility error')
+    end
+  end
+end

--- a/spec/hyrax/migrator/services/verify_visibility_service_spec.rb
+++ b/spec/hyrax/migrator/services/verify_visibility_service_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Hyrax::Migrator::Services::VerifyVisibilityService do
   let(:migrated_work) { double }
 
   before do
-    allow(Hyrax::Migrator::Services::VerificationService::MigratedWork).to receive(:new).and_return(migrated_work)
     allow(migrated_work).to receive(:asset).and_return(asset)
     allow(migrated_work).to receive(:original_profile).and_return(original_profile)
   end


### PR DESCRIPTION
fixes #247 
Based on a new VerifyService class that uses a new MigratedWork class (added in different branch)  to simplify using the verifier services.
Moves methods (especially lookup) from the VisibilityLookup class into a module in order to make them usable in the verifier
Changes syntax in VisibilityLookupPreflight lookup_visibility method to match the same method in VisibilityLookupService
