### PR TITLE
call model_name on asset

### DIFF
--- a/app/services/hyrax/migrator/services/verify_checksums_service.rb
+++ b/app/services/hyrax/migrator/services/verify_checksums_service.rb
@@ -23,7 +23,7 @@ module Hyrax::Migrator::Services
 
     def verify
       @errors = []
-      return @errors if @migrated_work.model_name.to_s == 'Generic'
+      return @errors if @migrated_work.asset.model_name.to_s == 'Generic'
 
       @errors << "Unable to verify #{ALGORITHM} checksums for #{@migrated_work.asset.id}." unless original_checksums['checksums'][ALGORITHM].first == new_content_checksum
       @errors

--- a/spec/hyrax/migrator/services/verify_checksums_service_spec.rb
+++ b/spec/hyrax/migrator/services/verify_checksums_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Hyrax::Migrator::Services::VerifyChecksumsService do
   before do
     allow(migrated_work).to receive(:asset).and_return(hyrax_work)
     allow(migrated_work).to receive(:working_directory).and_return('some_path')
-    allow(migrated_work).to receive(:model_name).and_return('Thing')
+    allow(hyrax_work).to receive(:model_name).and_return('Thing')
     allow(hyrax_work).to receive(:as_json).and_return(json)
     allow(hyrax_work).to receive(:file_sets).and_return([file_set])
     allow(YAML).to receive(:load_file).and_return(YAML.load_file('spec/fixtures/data/df70jh899_checksums.yml'))
@@ -62,7 +62,7 @@ RSpec.describe Hyrax::Migrator::Services::VerifyChecksumsService do
     context 'when the asset is a compound object' do
       before do
         allow(YAML).to receive(:load_file).and_raise(Errno::ENOENT)
-        allow(migrated_work).to receive(:model_name).and_return('Generic')
+        allow(hyrax_work).to receive(:model_name).and_return('Generic')
       end
 
       it 'returns no errors' do


### PR DESCRIPTION
fixes call directly on parent object rather than child for verify checksums service #306