### PR TITLE
Adds in actor which utilizes service to add permission to collection

### DIFF
--- a/app/actors/hyrax/migrator/actors/add_collection_permission_actor.rb
+++ b/app/actors/hyrax/migrator/actors/add_collection_permission_actor.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Hyrax::Migrator::Actors
+  # Add permissions to collections that are already persisted.
+  class AddCollectionPermissionActor < Hyrax::Migrator::Actors::AbstractActor
+    aasm do
+      state :add_collection_permission_initial, initial: true
+      state :add_collection_permission_succeeded, :add_collection_permission_failed
+
+      event :add_collection_permission_initial do
+        transitions from: %i[add_collection_permission_initial add_collection_permission_failed],
+                    to: :add_collection_permission_initial
+      end
+      event :add_collection_permission_failed, after: :post_fail do
+        transitions from: :add_collection_permission_initial,
+                    to: :add_collection_permission_failed
+      end
+      event :add_collection_permission_succeeded, after: :post_success do
+        transitions from: :add_collection_permission_initial,
+                    to: :add_collection_permission_succeeded
+      end
+    end
+
+    HAS_CHILD = 'Collection Permission added.'
+    NO_CHILD = 'No Collection Permission to add.'
+
+    ##
+    # Use the PermissionsCreateService to add permissions to collections in Hyrax.
+    def create(work)
+      super
+      if !work.collection?
+        @message = NO_CHILD
+        add_collection_permission_succeeded
+      else
+        call_service
+      end
+    rescue StandardError => e
+      add_collection_permission_failed
+      log("failed while adding collection permission to collection work: #{e.message}")
+    end
+
+    private
+
+    def call_service
+      @message = HAS_CHILD
+      add_collection_permission_initial
+      update_work(aasm.current_state)
+      service ? add_collection_permission_succeeded : add_collection_permission_failed
+    end
+
+    #:nocov:
+    def service
+      @service ||= Hyrax::Collections::PermissionsCreateService.add_access(collection_id: @work.id, grants: [{agent_type: Hyrax::PermissionTemplateAccess::USER, 
+                                                                                                              agent_id: @user.user_key, 
+                                                                                                              access: Hyrax::PermissionTemplateAccess::MANAGE }])
+    end
+    #:nocov:
+
+    def post_fail
+      failed(aasm.current_state, "Work #{@work.pid} failed adding collection permission.", Hyrax::Migrator::Work::FAIL)
+    end
+
+    def post_success
+      succeeded(aasm.current_state, "Work #{@work.pid} #{@message}", Hyrax::Migrator::Work::SUCCESS)
+    end
+  end
+end
+

--- a/lib/hyrax/migrator/middleware/configuration.rb
+++ b/lib/hyrax/migrator/middleware/configuration.rb
@@ -25,6 +25,7 @@ module Hyrax
             Hyrax::Migrator::Actors::ListChildrenActor,
             Hyrax::Migrator::Actors::ChildrenAuditActor,
             Hyrax::Migrator::Actors::PersistWorkActor,
+            Hyrax::Migrator::Actors::AddCollectionPermissionActor,
             Hyrax::Migrator::Actors::AddRelationshipsActor,
             Hyrax::Migrator::Actors::WorkflowMetadataActor,
             Hyrax::Migrator::Actors::TerminalActor

--- a/spec/hyrax/migrator/actors/add_collection_permission_actor_spec.rb
+++ b/spec/hyrax/migrator/actors/add_collection_permission_actor_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Migrator::Actors::AddCollectionPermissionActor do
+  let(:actor) { described_class.new }
+  let(:terminal) { Hyrax::Migrator::Actors::TerminalActor.new }
+  let(:work) { create(:collection, pid: pid) }
+  let(:pid) { '3t945r08v' }
+  let(:config) { Hyrax::Migrator::Configuration.new }
+  let(:service) { double }
+
+  before do
+    allow(actor).to receive(:config).and_return(config)
+  end
+
+  describe '#create' do
+    context 'when the work is not a collection' do
+      before do
+        allow(actor).to receive(:service).and_return(service)
+        actor.next_actor = terminal
+        actor.create(work)
+        allow(work).to receive(:collection?).and_return(false)
+      end
+
+      it 'goes straight to succeeded' do
+        expect(work.aasm_state).to eq('add_collection_permission_succeeded')
+      end
+      it 'displays the correct message' do
+        expect(work.status_message).to eq("Work #{work.pid} No Collection Permission to add.")
+      end
+    end
+
+    context 'when the service succeeds' do
+      before do
+        allow(actor).to receive(:service).and_return(service)
+        allow(service).to receive(:add_access).and_return(true)
+        actor.next_actor = terminal
+        allow(work).to receive(:collection?).and_return(true)
+      end
+
+      it 'sets the proper state' do
+        actor.create(work)
+        expect(work.aasm_state).to eq('add_collection_permission_succeeded')
+      end
+
+      it 'sets the status message' do
+        actor.create(work)
+        expect(work.status_message).to eq("Work #{work.pid} Collection Permission added.")
+      end
+
+      it 'sets the status' do
+        actor.create(work)
+        expect(work.status).to eq('success')
+      end
+
+      it 'calls the next actor' do
+        expect(terminal).to receive(:create)
+        actor.create(work)
+      end
+    end
+
+    context 'when the service fails' do
+      before do
+        allow(actor).to receive(:service).and_return(service)
+        allow(service).to receive(:add_access).and_return(false)
+        actor.next_actor = terminal
+      end
+
+      it 'sets the proper state' do
+        actor.create(work)
+        expect(work.aasm_state).to eq('add_relationships_failed')
+      end
+
+      it 'sets the status message' do
+        actor.create(work)
+        expect(work.status_message).to eq("Work #{work.pid} failed adding collection permission.")
+      end
+
+      it 'sets the status' do
+        actor.create(work)
+        expect(work.status).to eq('fail')
+      end
+
+      it 'does not call the next actor' do
+        expect(terminal).not_to receive(:create)
+        actor.create(work)
+      end
+    end
+
+    context 'when the service raises an exception' do
+      before do
+        allow(actor).to receive(:service).and_return(service)
+        allow(service).to receive(:add_access).and_raise(StandardError)
+        actor.next_actor = terminal
+      end
+
+      it 'sets the proper state' do
+        actor.create(work)
+        expect(work.aasm_state).to eq('add_collection_permission_failed')
+      end
+
+      it 'sets the status message' do
+        actor.create(work)
+        expect(work.status_message).to eq("Work #{work.pid} failed adding collection permission.")
+      end
+
+      it 'sets the status' do
+        actor.create(work)
+        expect(work.status).to eq('fail')
+      end
+
+      it 'does not call the next actor' do
+        expect(terminal).not_to receive(:create)
+        actor.create(work)
+      end
+
+      it 'logs the failure' do
+        expect(Rails.logger).to receive(:warn)
+        actor.create(work)
+      end
+    end
+  end
+end

--- a/spec/hyrax/migrator/middleware/configuration_spec.rb
+++ b/spec/hyrax/migrator/middleware/configuration_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Hyrax::Migrator::Middleware::Configuration do
       Hyrax::Migrator::Actors::ChildrenAuditActor,
       Hyrax::Migrator::Actors::PersistWorkActor,
       Hyrax::Migrator::Actors::AddRelationshipsActor,
+      Hyrax::Migrator::Actors::AddCollectionPermissionActor,
       Hyrax::Migrator::Actors::WorkflowMetadataActor,
       Hyrax::Migrator::Actors::TerminalActor
     ]


### PR DESCRIPTION
@lsat12357 I want to write some tests for this, but I'd like your input on this. I plugged into the actor stack to utilize a new actor which adds the permissions. The service already exists in hyrax, so i'm just utilizing that here instead of creating my own `Hyrax::Collections::PermissionsCreateService`. It still utilizes the state machine structure and adheres to that. Only difference is that i'm calling the method on the service in a different spot than the other ones typically do (seen on lines 48 and 53)